### PR TITLE
Fix Cloudflare preview cleanup by removing unsupported per_page param…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/node:20-slim
+FROM library/node:24-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/node:21-slim
+FROM library/node:20-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -102,12 +102,12 @@ jobs:
             };
 
             // List deployments (with pagination) and delete those matching this PR's branch alias
+            // Note: the Pages deployments API does not support the per_page parameter
             const deployments = [];
             let page = 1;
-            const perPage = 100;
 
             while (true) {
-              const url = `${baseUrl}?page=${page}&per_page=${perPage}`;
+              const url = `${baseUrl}?page=${page}`;
               const res = await fetch(url, { headers });
               if (!res.ok) {
                 core.warning(`Failed to list deployments on page ${page}: ${res.status}`);

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -49,12 +49,26 @@ jobs:
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
         with:
           script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            // Discover presentations from the build output
+            const siteDir = path.join(process.env.GITHUB_WORKSPACE, '_site');
+            const presentations = fs.readdirSync(siteDir, { withFileTypes: true })
+              .filter(d => d.isDirectory())
+              .map(d => d.name)
+              .sort();
+
+            const rows = presentations.map(p =>
+              `| ${p} | ${process.env.DEPLOYMENT_URL}/${p}/ |`
+            ).join('\n');
+
             const body = `### Preview Deployment\n\nThis PR has been deployed for preview:\n\n` +
-              `| Presentation | URL |\n|---|---|\n` +
-              `| cloud-migrations | ${{ steps.deploy.outputs.deployment-url }}/cloud-migrations/ |\n` +
-              `| secure-landing-zones | ${{ steps.deploy.outputs.deployment-url }}/secure-landing-zones/ |\n`;
+              `| Presentation | URL |\n|---|---|\n${rows}\n`;
 
             // Find existing bot comment
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
…eter

The Cloudflare Pages deployments list API does not support the per_page query parameter. Sending per_page=100 caused the API to return error 8000024, which made the cleanup script silently exit without deleting any preview deployments.

https://claude.ai/code/session_017RTXKBkBit7tvba44gT541