### PR TITLE
Address Copilot review feedback on docker training slides

### DIFF
--- a/docker-training/sections/containers-vs-vms.html
+++ b/docker-training/sections/containers-vs-vms.html
@@ -31,8 +31,8 @@
     </div>
   </div>
   <span class="text-sm">
-    <a href="https://docs.docker.com/get-started/" target="_blank"
-      >https://docs.docker.com/get-started/</a
+    <a href="https://docs.docker.com/get-started/docker-overview/" target="_blank"
+      >https://docs.docker.com/get-started/docker-overview/</a
     >
   </span>
 </section>

--- a/docker-training/sections/containers-vs-vms.html
+++ b/docker-training/sections/containers-vs-vms.html
@@ -31,8 +31,8 @@
     </div>
   </div>
   <span class="text-sm">
-    <a href="https://www.docker.com/what-container" target="_blank"
-      >https://www.docker.com/what-container</a
+    <a href="https://docs.docker.com/get-started/" target="_blank"
+      >https://docs.docker.com/get-started/</a
     >
   </span>
 </section>

--- a/docker-training/sections/docker-desktop.html
+++ b/docker-training/sections/docker-desktop.html
@@ -16,7 +16,7 @@
   </span>
 </section>
 <section>
-  <h2>Docker Architecture</h2>
+  <h2>Docker Desktop Architecture</h2>
   <div class="flex justify-center">
     <img
       class="rounded"

--- a/docker-training/sections/docker-images.html
+++ b/docker-training/sections/docker-images.html
@@ -4,7 +4,7 @@
   <div class="grid grid-cols-2 gap-4">
     <div>
       <pre><code class="language-dockerfile" data-trim>
-FROM ubuntu:15.04
+FROM ubuntu:24.04
 COPY . /app
 RUN make /app
 CMD python /app/app.py

--- a/docker-training/sections/introduction.html
+++ b/docker-training/sections/introduction.html
@@ -10,7 +10,7 @@
   <h2>Participants Today</h2>
   <h4>Who are you?</h4>
   <ul>
-    <li>Where and what do you work?</li>
+    <li>Where do you work and what do you do?</li>
     <li>What is your background?</li>
     <li>Do you have experience with Docker or Containers?</li>
   </ul>

--- a/docker-training/sections/resources.html
+++ b/docker-training/sections/resources.html
@@ -3,17 +3,17 @@
   <h2>Docker Resources</h2>
   <ul>
     <li>
-      <a href="http://play-with-docker.com" target="_blank"
+      <a href="https://play-with-docker.com" target="_blank"
         >Play with Docker</a
       >
     </li>
     <li>
-      <a href="https://github.com/56KCloud/Training/Resources" target="_blank"
+      <a href="https://github.com/56KCloud/Training/tree/main/Resources" target="_blank"
         >56KCloud Training Resources</a
       >
     </li>
     <li>
-      <a href="http://veggiemonk.github.io/awesome-docker/" target="_blank"
+      <a href="https://veggiemonk.github.io/awesome-docker/" target="_blank"
         >Awesome Docker</a
       >
     </li>


### PR DESCRIPTION
- Use HTTPS instead of HTTP for play-with-docker and awesome-docker links
- Fix invalid GitHub URL for 56KCloud Training Resources
- Rename duplicate "Docker Architecture" heading to "Docker Desktop Architecture"
- Update obsolete ubuntu:15.04 to ubuntu:24.04 in Dockerfile example
- Fix grammar: "Where and what do you work?" → "Where do you work and what do you do?"
- Replace dead docker.com/what-container link with docs.docker.com/get-started/

https://claude.ai/code/session_014L2DHkoioyJHYgvdHB3Bwx