### PR TITLE
Fix remaining Copilot review suggestions on docker training slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ In this repo, you will find all my presentations using [reveal.js](https://revea
 
 - [Cloud Migrations](https://elft3r.github.io/presentations/cloud-migrations/)
 - [Secure Landing Zones](https://elft3r.github.io/presentations/secure-landing-zones/)
+- [Docker Training](https://elft3r.github.io/presentations/docker-training/)

--- a/docker-training/sections/containers-vs-vms.html
+++ b/docker-training/sections/containers-vs-vms.html
@@ -1,6 +1,6 @@
-<section><h1>Containers vs VM's</h1></section>
+<section><h1>Containers vs VMs</h1></section>
 <section>
-  <h2>Containers vs VM's</h2>
+  <h2>Containers vs VMs</h2>
   <div class="flex justify-center">
     <img
       class="rounded"
@@ -11,7 +11,7 @@
   </div>
 </section>
 <section>
-  <h2>Containers vs VM's</h2>
+  <h2>Containers vs VMs</h2>
   <div class="grid grid-cols-2 gap-4">
     <div>
       <h3><em>Containers</em></h3>
@@ -22,7 +22,7 @@
       />
     </div>
     <div>
-      <h3><em>VM's</em></h3>
+      <h3><em>VMs</em></h3>
       <img
         class="rounded"
         src="imgs/vm-stack.png"

--- a/docker-training/sections/docker-commands.html
+++ b/docker-training/sections/docker-commands.html
@@ -12,7 +12,6 @@ $ docker inspect    # inspect container or image details
   <h2>Top Docker Commands &mdash; Images</h2>
   <pre><code class="language-bash" data-trim>
 $ docker build      # builds a Dockerfile into an image
-$ docker inspect    # inspect contents of an image
 $ docker login      # login to Container Image Registry
 $ docker pull       # pull image from Container Registry
 $ docker rmi        # remove image

--- a/docker-training/sections/docker-labs.html
+++ b/docker-training/sections/docker-labs.html
@@ -1,6 +1,6 @@
 <section><h1>Docker Labs</h1></section>
 <section>
-  <h2>Training Agenda</h2>
+  <h2>Docker Labs Agenda</h2>
   <ul>
     <li>Docker Desktop</li>
     <li>Docker CLI Overview</li>


### PR DESCRIPTION
- Add docker-training presentation link to README.md
- Rename duplicate "Training Agenda" to "Docker Labs Agenda" in docker-labs.html
- Remove duplicate docker inspect entry from docker-commands.html Images section
- Fix grammar: "VM's" → "VMs" (no apostrophe for plurals) in containers-vs-vms.html

https://claude.ai/code/session_018yB5s12p5Q5Gme3jpJaaVZ