### PR TITLE
Align section-title slide padding with card component

### DIFF
--- a/custom-themes/white_contrast_compact_verbatim_headers.css
+++ b/custom-themes/white_contrast_compact_verbatim_headers.css
@@ -387,6 +387,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
 .reveal section.section-title {
   background: var(--r-accent-gradient);
   border-radius: 0.75em;
+  padding: 1.2em;
 }
 
 .reveal section.section-title h1,


### PR DESCRIPTION
The section-title slides shared the same border-radius (0.75em) as cards
but lacked explicit padding, relying on reveal.js defaults. Added matching
padding (1.2em) to ensure consistent internal spacing between both elements.

https://claude.ai/code/session_01SsaNs2RkG3yM3qazRnUScY