### PR TITLE
Fix section title green background overflow to the right

### DIFF
--- a/custom-themes/white_contrast_compact_verbatim_headers.css
+++ b/custom-themes/white_contrast_compact_verbatim_headers.css
@@ -388,6 +388,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   background: var(--r-accent-gradient);
   border-radius: 0.75em;
   padding: 1.2em;
+  box-sizing: border-box;
 }
 
 .reveal section.section-title h1,


### PR DESCRIPTION
Add box-sizing: border-box to .section-title so padding is included within the element's width instead of extending beyond it.

https://claude.ai/code/session_01S1zx9bTdfFd4R3Vv5ZS8JV