### PR TITLE
Update Docker Labs agenda to match training kickstart chapters

### DIFF
--- a/docker-training/sections/docker-commands.html
+++ b/docker-training/sections/docker-commands.html
@@ -35,8 +35,8 @@ $ docker rm         # remove container
 <section>
   <h2>Let's Get Started!</h2>
   <p>
-    <a href="https://github.com/56kcloud/training" target="_blank" rel="noopener noreferrer"
-      >github.com/56kcloud/training</a
+    <a href="https://training.new-bridge.dev/Docker/kickstart/README.html" target="_blank" rel="noopener noreferrer"
+      >training.new-bridge.dev/Docker/kickstart</a
     >
   </p>
 </section>

--- a/docker-training/sections/docker-labs.html
+++ b/docker-training/sections/docker-labs.html
@@ -2,11 +2,20 @@
 <section>
   <h2>Docker Labs Agenda</h2>
   <ul class="styled-list">
-    <li>Docker Desktop</li>
-    <li>Docker CLI Overview</li>
-    <li>Docker and Running Containers</li>
-    <li>Running Webapps</li>
-    <li>Create a Docker Build pipeline</li>
-    <li>Deploy apps with Docker Compose</li>
+    <li>Setup</li>
+    <li>Our First Containers</li>
+    <li>Deploying Webapps with Docker</li>
+    <li>Docker Images and Volumes</li>
+    <li>Webapps with Docker Part Deux</li>
+    <li>Docker and DevOps</li>
+    <li>Deploying an app with Docker Compose</li>
+    <li>Deploying an app to a Swarm</li>
+    <li>Docker Networking Basics</li>
+    <li>Bridge Networking</li>
+    <li>Managing Docker Secrets</li>
+    <li>Deploying MongoDB</li>
+    <li>MongoDB with Node-RED</li>
+    <li>Node-RED with Docker</li>
+    <li>Next Steps</li>
   </ul>
 </section>

--- a/docker-training/sections/docker-labs.html
+++ b/docker-training/sections/docker-labs.html
@@ -2,20 +2,11 @@
 <section>
   <h2>Docker Labs Agenda</h2>
   <ul class="styled-list">
-    <li>Setup</li>
-    <li>Our First Containers</li>
-    <li>Deploying Webapps with Docker</li>
-    <li>Docker Images and Volumes</li>
-    <li>Webapps with Docker Part Deux</li>
-    <li>Docker and DevOps</li>
-    <li>Deploying an app with Docker Compose</li>
-    <li>Deploying an app to a Swarm</li>
-    <li>Docker Networking Basics</li>
-    <li>Bridge Networking</li>
-    <li>Managing Docker Secrets</li>
-    <li>Deploying MongoDB</li>
-    <li>MongoDB with Node-RED</li>
-    <li>Node-RED with Docker</li>
-    <li>Next Steps</li>
+    <li>Getting Started</li>
+    <li>Webapps & Images</li>
+    <li>DevOps & Compose</li>
+    <li>Orchestration</li>
+    <li>Networking & Security</li>
+    <li>Advanced Apps</li>
   </ul>
 </section>

--- a/docker-training/sections/docker-labs.html
+++ b/docker-training/sections/docker-labs.html
@@ -3,10 +3,10 @@
   <h2>Docker Labs Agenda</h2>
   <ul class="styled-list">
     <li>Getting Started</li>
-    <li>Webapps & Images</li>
-    <li>DevOps & Compose</li>
+    <li>Webapps &amp; Images</li>
+    <li>DevOps &amp; Compose</li>
     <li>Orchestration</li>
-    <li>Networking & Security</li>
+    <li>Networking &amp; Security</li>
     <li>Advanced Apps</li>
   </ul>
 </section>

--- a/docker-training/sections/resources.html
+++ b/docker-training/sections/resources.html
@@ -8,8 +8,8 @@
       >
     </li>
     <li>
-      <a href="https://github.com/56KCloud/Training/tree/main/Resources" target="_blank" rel="noopener noreferrer"
-        >56KCloud Training Resources</a
+      <a href="https://training.new-bridge.dev/Docker/kickstart/README.html" target="_blank" rel="noopener noreferrer"
+        >Docker Kickstart Training</a
       >
     </li>
     <li>


### PR DESCRIPTION
Replace the hardcoded lab list with the full chapter list from
elft3r/training Docker/kickstart, ordered by nav_order.

https://claude.ai/code/session_01WDQNwenqMSqnyBAqApvDgx