### PR TITLE
fix: establish proper heading hierarchy across all presentations

### DIFF
--- a/.claude/agents/design-review.md
+++ b/.claude/agents/design-review.md
@@ -46,7 +46,7 @@ Only these colors should appear in slide HTML. Any hardcoded color not in this l
 | `--r-link-color` | `#B39A6A` | Links |
 | `--r-link-color-hover` | `#C9B48A` | Link hover |
 | `--r-main-color` | `#2d3748` | Body text |
-| `--r-heading-color` | `#1a202c` | Headings h1, h2 |
+| `--r-heading-color` | `#1a202c` | Headings h1, h2 (note: `.section-title` overrides to white) |
 | `--r-muted-color` | `#718096` | Source attribution, subtle text |
 | `--r-card-border` | `#e2e8f0` | Card and code block borders |
 | `--r-background-color` | `#F8F9FA` | Page background |
@@ -59,8 +59,8 @@ Only these colors should appear in slide HTML. Any hardcoded color not in this l
 
 | Component | Required Class | Common Mistakes |
 |---|---|---|
-| Title slides | `<section class="section-title">...</section>` with nested `.title-slide` content (e.g., `*/sections/header.html`, typically using `<h2>`) | Flagging valid header/title slides for not using the simple divider pattern |
-| Section dividers | `<section class="section-title"><h1>...</h1></section>` | Missing `section-title` class on divider slides; using the divider `<h1>` rule to flag title slides |
+| Title slides | `<section class="section-title">...</section>` with nested `.title-slide` content (e.g., `*/sections/header.html`, using `<h1>` for the main title and `<h2>` for the subtitle) | Flagging valid header/title slides for not using the simple divider pattern |
+| Section dividers | `<section class="section-title"><h2>...</h2></section>` | Missing `section-title` class on divider slides; using `<h1>` instead of `<h2>` for section dividers |
 | Cards | `.card` on container div | Missing `.card` class; manually re-creating card styles inline; adding inline accent borders (`border-top`, `border-left`) — the base `.card` styling (border + shadow) is sufficient |
 | Lists | `ul.styled-list` for content lists | Plain `<ul>` without `styled-list` — acceptable only inside cards or for very short lists |
 | Icons | `.icon-accent` wrapping `<i class="fa-solid fa-...">` | Icon `<span>` without `.icon-accent` class |
@@ -78,12 +78,14 @@ Only these colors should appear in slide HTML. Any hardcoded color not in this l
 
 ### Typography & Heading Hierarchy
 
-- Each content slide should have exactly one `<h2>` as its title (auto-styled with accent bottom border).
-- `<h3>` for sub-headings within slides (auto-colored in accent).
+The presentations follow a strict heading hierarchy: `<h1>` (presentation title) → `<h2>` (section dividers / subtitle) → `<h3>` (content sub-headings).
+
+- **`<h1>`**: Reserved exclusively for the **presentation title** on the title slide (inside `.title-slide`). There should be exactly one `<h1>` per presentation.
+- **`<h2>`**: Used for **section divider titles** (inside `.section-title`) and the **title slide subtitle** (inside `.title-slide`). Also used as the **main heading on content slides** (auto-styled with accent bottom border). The theme overrides `.section-title h2` to use the larger `--r-heading1-size` (2.5em) so section dividers remain visually prominent.
+- **`<h3>`**: Used for **sub-headings within content slides** (auto-colored in accent) and **section divider subtitles** (e.g., "Use Case" below the section title). The theme styles `.section-title h3` with `color: rgba(255, 255, 255, 0.8)` for a lighter secondary appearance.
 - Use `<em>` inside headings for emphasis (renders italic + accent color).
-- Title/divider slides may use a single heading inside `.section-title`: use `<h1>` for section dividers, and allow `<h2>` for header/title-slide templates that follow the established repository pattern (e.g., `*/sections/header.html`).
-- **Title slide subtitles**: Inside `.title-slide`, use `<h4>` for the presentation subtitle (e.g., "Best Practices & Learnings"). The theme styles `.title-slide h4` with `color: var(--r-muted-color)` and `font-weight: 400`, and `.section-title h4` with `color: rgba(255, 255, 255, 0.8)` — giving it a lighter, secondary appearance on both light and dark backgrounds. The `h2 → h4` skip is **intentional** in this context and should **not** be flagged. Do **not** suggest changing the subtitle to `<h3>` (which would get accent color styling and break the visual hierarchy).
-- **Flag**: `<h1>` used on regular content slides or outside title/divider contexts; heading levels skipped (h2 → h4) **on content slides** (not title slides — see subtitle rule above); multiple `<h2>` in one content `<section>`; `.section-title` slides with multiple top-level headings.
+- **Title slide structure**: Inside `.title-slide`, use `<h1>` for the main presentation title and `<h2>` for the subtitle. The theme styles `.title-slide h1` at 2.2em without a bottom border, and `.title-slide h2` with `color: var(--r-muted-color)`, `font-weight: 400`, and no bottom border.
+- **Flag**: `<h1>` used outside the title slide; heading levels skipped on content slides; multiple `<h2>` in one content `<section>`; `.section-title` divider slides using `<h1>` instead of `<h2>`; `.section-title` slides with multiple top-level headings.
 
 ### Images
 
@@ -170,7 +172,7 @@ The theme includes a `@media print` block that sets the background color. Be awa
 
 #### Language & Structure
 - If a slide contains content in a language different from the presentation default, use `lang="..."` on the containing element.
-- Do not skip heading levels (h2 → h4). Assistive tech uses heading hierarchy for navigation.
+- Do not skip heading levels on content slides. The proper hierarchy is h1 (title slide only) → h2 (section dividers + content slide titles) → h3 (sub-headings). Assistive tech uses heading hierarchy for navigation.
 - Lists of content should use semantic `<ul>`/`<ol>`, not `<div>` with visual bullet characters.
 
 #### Flag Summary

--- a/.claude/agents/design-review.md
+++ b/.claude/agents/design-review.md
@@ -78,13 +78,14 @@ Only these colors should appear in slide HTML. Any hardcoded color not in this l
 
 ### Typography & Heading Hierarchy
 
-The presentations follow a strict heading hierarchy: `<h1>` (presentation title) → `<h2>` (section dividers / subtitle) → `<h3>` (content sub-headings).
+The presentations follow a heading hierarchy: `<h1>` (presentation title) → `<h2>` (section dividers / subtitle / content slide titles) → `<h3>` (content sub-headings). `<h4>` is used sparingly for decorative labels inside cards.
 
 - **`<h1>`**: Reserved exclusively for the **presentation title** on the title slide (inside `.title-slide`). There should be exactly one `<h1>` per presentation.
 - **`<h2>`**: Used for **section divider titles** (inside `.section-title`) and the **title slide subtitle** (inside `.title-slide`). Also used as the **main heading on content slides** (auto-styled with accent bottom border). The theme overrides `.section-title h2` to use the larger `--r-heading1-size` (2.5em) so section dividers remain visually prominent.
 - **`<h3>`**: Used for **sub-headings within content slides** (auto-colored in accent) and **section divider subtitles** (e.g., "Use Case" below the section title). The theme styles `.section-title h3` with `color: rgba(255, 255, 255, 0.8)` for a lighter secondary appearance.
+- **`<h4>`**: Used only for **decorative category labels** inside cards (e.g., icon + short label like "Key Characteristics"). These are styled inline at small sizes and are **not** structural headings. Do **not** flag `<h4>` usage inside `.card` elements.
 - Use `<em>` inside headings for emphasis (renders italic + accent color).
-- **Title slide structure**: Inside `.title-slide`, use `<h1>` for the main presentation title and `<h2>` for the subtitle. The theme styles `.title-slide h1` at 2.2em without a bottom border, and `.title-slide h2` with `color: var(--r-muted-color)`, `font-weight: 400`, and no bottom border.
+- **Title slide structure**: Inside `.title-slide`, use `<h1>` for the main presentation title and `<h2>` for the subtitle. The theme styles `.title-slide h1` at 2.2em without a bottom border, and `.title-slide h2` with `color: rgba(255, 255, 255, 0.8)`, `font-weight: 400`, and no bottom border.
 - **Flag**: `<h1>` used outside the title slide; heading levels skipped on content slides; multiple `<h2>` in one content `<section>`; `.section-title` divider slides using `<h1>` instead of `<h2>`; `.section-title` slides with multiple top-level headings.
 
 ### Images

--- a/cloud-migrations/index.html
+++ b/cloud-migrations/index.html
@@ -40,7 +40,7 @@
         ></section>
         <section data-external="sections/technical.html"></section>
         <section data-external="sections/learnings.html"></section>
-        <section class="section-title" aria-label="Questions and Answers"><h1>Q&A</h1></section>
+        <section class="section-title" aria-label="Questions and Answers"><h2>Q&A</h2></section>
       </div>
     </div>
 

--- a/cloud-migrations/sections/cloud.html
+++ b/cloud-migrations/sections/cloud.html
@@ -1,5 +1,5 @@
 <section class="section-title" aria-label="Section: Cloud">
-  <h1>Cloud</h1>
+  <h2>Cloud</h2>
 </section>
 <section>
   <h2>Cloud Evolution</h2>

--- a/cloud-migrations/sections/header.html
+++ b/cloud-migrations/sections/header.html
@@ -1,8 +1,8 @@
 <section class="section-title" aria-label="Title: Cloud Migration - Best Practices & Learnings">
   <div class="flex flex-col">
     <div class="title-slide">
-      <h2>Cloud Migration</h2>
-      <h4>Best Practices & Learnings</h4>
+      <h1>Cloud Migration</h1>
+      <h2>Best Practices & Learnings</h2>
       <hr class="divider" />
       <div class="author">Jochen Zehnder</div>
     </div>

--- a/cloud-migrations/sections/learnings.html
+++ b/cloud-migrations/sections/learnings.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Learnings"><h1>Learnings</h1></section>
+<section class="section-title" aria-label="Section: Learnings"><h2>Learnings</h2></section>
 <section>
   <h2>Learnings</h2>
   <div class="grid grid-cols-3 gap-6">

--- a/cloud-migrations/sections/legal.html
+++ b/cloud-migrations/sections/legal.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Legal"><h1>Legal</h1></section>
+<section class="section-title" aria-label="Section: Legal"><h2>Legal</h2></section>
 <section>
   <h2>I'm not a lawyer</h2>
   <div class="fragment">

--- a/cloud-migrations/sections/migrate-regulated-company.html
+++ b/cloud-migrations/sections/migrate-regulated-company.html
@@ -1,6 +1,6 @@
 <section class="section-title" aria-label="Section: Migration of Regulated Company">
-  <h1>Migration of Regulated Company</h1>
-  <h4>Use Case</h4>
+  <h2>Migration of Regulated Company</h2>
+  <h3>Use Case</h3>
 </section>
 <section>
   <h2>Use Case</h2>

--- a/cloud-migrations/sections/migration-strategies.html
+++ b/cloud-migrations/sections/migration-strategies.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Migration Strategies"><h1>Migration Strategies</h1></section>
+<section class="section-title" aria-label="Section: Migration Strategies"><h2>Migration Strategies</h2></section>
 <section>
   <h2>What is cloud migration?</h2>
   <q>

--- a/cloud-migrations/sections/security.html
+++ b/cloud-migrations/sections/security.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Security"><h1>Security</h1></section>
+<section class="section-title" aria-label="Section: Security"><h2>Security</h2></section>
 <section>
   <h2>Security</h2>
   <div>

--- a/cloud-migrations/sections/technical.html
+++ b/cloud-migrations/sections/technical.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Technical"><h1>Technical</h1></section>
+<section class="section-title" aria-label="Section: Technical"><h2>Technical</h2></section>
 <section>
   <h2>How to structure your Cloud?</h2>
   <ul class="styled-list">

--- a/custom-themes/white_contrast_compact_verbatim_headers.css
+++ b/custom-themes/white_contrast_compact_verbatim_headers.css
@@ -395,12 +395,15 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
 .reveal section.section-title h2 {
   color: #fff;
   border-bottom: none;
+  padding-bottom: 0;
+  width: auto;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   font-size: var(--r-heading1-size);
 }
 
 .reveal section.section-title h3 {
   color: rgba(255, 255, 255, 0.8);
+  font-size: var(--r-heading4-size);
 }
 
 .reveal section.section-title .author {
@@ -503,17 +506,16 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
 /*********************************************
  * TITLE SLIDE STYLING
  *********************************************/
-.reveal .title-slide h1 {
-  border-bottom: none;
+.reveal section.section-title .title-slide h1 {
   font-size: 2.2em;
   margin-bottom: 0.1em;
 }
 
-.reveal .title-slide h2 {
-  color: var(--r-muted-color);
+.reveal section.section-title .title-slide h2 {
+  color: rgba(255, 255, 255, 0.8);
   font-weight: 400;
-  border-bottom: none;
   font-size: var(--r-heading2-size);
+  text-shadow: none;
 }
 
 .reveal .title-slide .author {

--- a/custom-themes/white_contrast_compact_verbatim_headers.css
+++ b/custom-themes/white_contrast_compact_verbatim_headers.css
@@ -396,9 +396,10 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   color: #fff;
   border-bottom: none;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  font-size: var(--r-heading1-size);
 }
 
-.reveal section.section-title h4 {
+.reveal section.section-title h3 {
   color: rgba(255, 255, 255, 0.8);
 }
 
@@ -502,15 +503,17 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
 /*********************************************
  * TITLE SLIDE STYLING
  *********************************************/
-.reveal .title-slide h2 {
+.reveal .title-slide h1 {
   border-bottom: none;
   font-size: 2.2em;
   margin-bottom: 0.1em;
 }
 
-.reveal .title-slide h4 {
+.reveal .title-slide h2 {
   color: var(--r-muted-color);
   font-weight: 400;
+  border-bottom: none;
+  font-size: var(--r-heading2-size);
 }
 
 .reveal .title-slide .author {

--- a/docker-training/index.html
+++ b/docker-training/index.html
@@ -48,7 +48,7 @@
         <section data-external="sections/docker-kubernetes.html"></section>
         <section data-external="sections/monitoring.html"></section>
         <section data-external="sections/resources.html"></section>
-        <section class="section-title" aria-label="Thank You closing slide"><h1>Thank You!</h1></section>
+        <section class="section-title" aria-label="Thank You closing slide"><h2>Thank You!</h2></section>
       </div>
     </div>
 

--- a/docker-training/sections/cloud-native.html
+++ b/docker-training/sections/cloud-native.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Cloud Native"><h1>Cloud Native</h1></section>
+<section class="section-title" aria-label="Section: Cloud Native"><h2>Cloud Native</h2></section>
 <section>
   <h2>What is Cloud Native?</h2>
   <q style="font-size: 0.7em; width: 85%;">

--- a/docker-training/sections/container-history.html
+++ b/docker-training/sections/container-history.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Container History"><h1>Container History</h1></section>
+<section class="section-title" aria-label="Section: Container History"><h2>Container History</h2></section>
 <section>
   <h2>What are containers?</h2>
   <p style="font-size: 1.1em; margin-bottom: 0.3rem;">A collection of <strong>kernel features</strong></p>

--- a/docker-training/sections/containers-vs-vms.html
+++ b/docker-training/sections/containers-vs-vms.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Containers vs VMs"><h1>Containers vs VMs</h1></section>
+<section class="section-title" aria-label="Section: Containers vs VMs"><h2>Containers vs VMs</h2></section>
 <section>
   <h2>Containers vs VMs</h2>
   <div style="position: relative; max-width: 70%; margin: 0 auto;">

--- a/docker-training/sections/devops-docker.html
+++ b/docker-training/sections/devops-docker.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>DevOps &amp; Docker</h1></section>
+<section class="section-title"><h2>DevOps &amp; Docker</h2></section>
 <section>
   <h2>DevOps</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/docker-commands.html
+++ b/docker-training/sections/docker-commands.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Commands</h1></section>
+<section class="section-title"><h2>Docker Commands</h2></section>
 <section>
   <h2>Top Docker Commands &mdash; Information</h2>
   <pre><code class="language-bash" data-trim>
@@ -29,8 +29,8 @@ $ docker rm         # remove container
   </code></pre>
 </section>
 <section class="section-title">
-  <h1>Docker Time</h1>
-  <h4>Let's have a look: DEMO</h4>
+  <h2>Docker Time</h2>
+  <h3>Let's have a look: DEMO</h3>
 </section>
 <section>
   <h2>Let's Get Started!</h2>

--- a/docker-training/sections/docker-compose.html
+++ b/docker-training/sections/docker-compose.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Compose</h1></section>
+<section class="section-title"><h2>Docker Compose</h2></section>
 <section>
   <h2>Compose Explained</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/docker-desktop.html
+++ b/docker-training/sections/docker-desktop.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Desktop</h1></section>
+<section class="section-title"><h2>Docker Desktop</h2></section>
 <section>
   <h2>Docker Architecture</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/docker-images.html
+++ b/docker-training/sections/docker-images.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Images</h1></section>
+<section class="section-title"><h2>Docker Images</h2></section>
 <section>
   <h2>Images &amp; Layers</h2>
   <div class="grid grid-cols-2 gap-6">

--- a/docker-training/sections/docker-kubernetes.html
+++ b/docker-training/sections/docker-kubernetes.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker &amp; Kubernetes</h1></section>
+<section class="section-title"><h2>Docker &amp; Kubernetes</h2></section>
 <section>
   <h2>Docker Architecture</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/docker-labs.html
+++ b/docker-training/sections/docker-labs.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Labs</h1></section>
+<section class="section-title"><h2>Docker Labs</h2></section>
 <section>
   <h2>Docker Labs Agenda</h2>
   <ul class="styled-list">

--- a/docker-training/sections/docker-networking.html
+++ b/docker-training/sections/docker-networking.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Networking</h1></section>
+<section class="section-title"><h2>Docker Networking</h2></section>
 <section>
   <h2>Overlay Network</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/docker-swarm.html
+++ b/docker-training/sections/docker-swarm.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Swarm</h1></section>
+<section class="section-title"><h2>Docker Swarm</h2></section>
 <section>
   <h2>Docker Swarm</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/docker-volumes.html
+++ b/docker-training/sections/docker-volumes.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Volumes</h1></section>
+<section class="section-title"><h2>Docker Volumes</h2></section>
 <section>
   <h2>Anonymous vs Named Volumes</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/header.html
+++ b/docker-training/sections/header.html
@@ -1,8 +1,8 @@
 <section class="section-title" aria-label="Title slide: Docker Training BFH">
   <div class="flex flex-col">
     <div class="title-slide">
-      <h2>Docker Training</h2>
-      <h4>BFH</h4>
+      <h1>Docker Training</h1>
+      <h2>BFH</h2>
       <hr class="divider" />
       <div class="author">Jochen Zehnder</div>
     </div>

--- a/docker-training/sections/introduction.html
+++ b/docker-training/sections/introduction.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Introduction"><h1>Introduction</h1></section>
+<section class="section-title" aria-label="Section: Introduction"><h2>Introduction</h2></section>
 <section>
   <h2>Participants Today</h2>
   <p style="font-size: 0.85em; color: var(--r-muted-color); margin: 0 0 0.3em;">Who are you?</p>

--- a/docker-training/sections/monitoring.html
+++ b/docker-training/sections/monitoring.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Monitoring</h1></section>
+<section class="section-title"><h2>Monitoring</h2></section>
 <section>
   <h2>Custom Monitoring</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/resources.html
+++ b/docker-training/sections/resources.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Docker Resources</h1></section>
+<section class="section-title"><h2>Docker Resources</h2></section>
 <section>
   <h2>Docker Resources</h2>
   <ul class="styled-list">

--- a/docker-training/sections/serverless.html
+++ b/docker-training/sections/serverless.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Serverless</h1></section>
+<section class="section-title"><h2>Serverless</h2></section>
 <section>
   <h2>Future == Serverless</h2>
   <div class="flex justify-center">

--- a/docker-training/sections/why-docker.html
+++ b/docker-training/sections/why-docker.html
@@ -1,4 +1,4 @@
-<section class="section-title" aria-label="Section: Why Docker / Containers?"><h1>Why Docker / Containers?</h1></section>
+<section class="section-title" aria-label="Section: Why Docker / Containers?"><h2>Why Docker / Containers?</h2></section>
 <section>
   <h2>Common IT Struggles</h2>
   <div class="grid grid-cols-2 gap-6">

--- a/secure-landing-zones/index.html
+++ b/secure-landing-zones/index.html
@@ -36,7 +36,7 @@
         <section data-external="sections/account-vending.html"></section>
         <section data-external="sections/security.html"></section>
         <section data-external="sections/learnings.html"></section>
-        <section class="section-title"><h1>Q&A</h1></section>
+        <section class="section-title"><h2>Q&A</h2></section>
       </div>
     </div>
 

--- a/secure-landing-zones/sections/account-vending.html
+++ b/secure-landing-zones/sections/account-vending.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Account Vending</h1></section>
+<section class="section-title"><h2>Account Vending</h2></section>
 <section>
   <h2>Account Vending</h2>
   <q>Automated and scalable system to (de)provision and configure accounts</q>

--- a/secure-landing-zones/sections/header.html
+++ b/secure-landing-zones/sections/header.html
@@ -1,7 +1,7 @@
 <section class="section-title">
   <div class="flex flex-col">
     <div class="title-slide">
-      <h2>Deploying Secure Landing Zones in highly regulated sectors</h2>
+      <h1>Deploying Secure Landing Zones in highly regulated sectors</h1>
       <hr class="divider" />
       <div class="author">Jochen Zehnder</div>
     </div>

--- a/secure-landing-zones/sections/landing-zone.html
+++ b/secure-landing-zones/sections/landing-zone.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>What is a Landing Zone?</h1></section>
+<section class="section-title"><h2>What is a Landing Zone?</h2></section>
 <section>
   <h2>What is a Landing Zone?</h2>
   <q

--- a/secure-landing-zones/sections/learnings.html
+++ b/secure-landing-zones/sections/learnings.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Learnings</h1></section>
+<section class="section-title"><h2>Learnings</h2></section>
 <section>
   <h2>Learnings</h2>
   <div class="grid grid-cols-3 gap-6">

--- a/secure-landing-zones/sections/legal.html
+++ b/secure-landing-zones/sections/legal.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Legal</h1></section>
+<section class="section-title"><h2>Legal</h2></section>
 <section>
   <h2>I'm not a lawyer</h2>
   <div class="fragment">

--- a/secure-landing-zones/sections/multi-account.html
+++ b/secure-landing-zones/sections/multi-account.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Multi-Account</h1></section>
+<section class="section-title"><h2>Multi-Account</h2></section>
 <section>
   <h2>Requirements</h2>
   <ul class="styled-list">

--- a/secure-landing-zones/sections/security.html
+++ b/secure-landing-zones/sections/security.html
@@ -1,4 +1,4 @@
-<section class="section-title"><h1>Security</h1></section>
+<section class="section-title"><h2>Security</h2></section>
 <section>
   <h2>What needs to be supported?</h2>
   <ul class="styled-list">


### PR DESCRIPTION
Title slides now use h1 for the main title and h2 for the subtitle,
section dividers use h2 (previously h1), and section divider subtitles
use h3 (previously h4). CSS updated to preserve visual appearance with
the new semantic hierarchy.

https://claude.ai/code/session_01GR9U13J1BnxRngQkF6TUfU