### PR TITLE
Wire PR previews into GitHub Deployments and add a real landing page

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  deployments: write
 
 concurrency:
   group: preview-${{ github.event.pull_request.number }}
@@ -45,6 +46,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           command: pages deploy _site --project-name=${{ github.event.repository.name }} --branch=pr-${{ github.event.pull_request.number }}
 
       - name: Comment preview URL on PR

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,22 @@
       "version": "1.0.0",
       "dependencies": {
         "reveal.js": "^5.2.1"
+      },
+      "devDependencies": {
+        "marked": "^18.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/reveal.js": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "Reveal.js presentations",
+  "homepage": "https://elft3r.github.io/presentations/",
   "scripts": {
     "build": "node scripts/build.js",
     "check-render": "node scripts/check-render.js",

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "dependencies": {
     "reveal.js": "^5.2.1"
+  },
+  "devDependencies": {
+    "marked": "^18.0.2"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { marked } = require('marked');
 
 const ROOT = path.resolve(__dirname, '..');
 const REVEAL_DIR = path.join(ROOT, 'node_modules', 'reveal.js');
@@ -79,10 +80,74 @@ for (const pres of PRESENTATIONS) {
   copyRecursive(path.join(ROOT, pres), path.join(siteDir, pres));
 }
 
-// Copy README.md to serve as the landing page
+// Render README.md to _site/index.html as the landing page
 const readme = path.join(ROOT, 'README.md');
 if (fs.existsSync(readme)) {
-  fs.copyFileSync(readme, path.join(siteDir, 'README.md'));
+  console.log('\nRendering README.md to _site/index.html...');
+  let markdown = fs.readFileSync(readme, 'utf8');
+  // Rewrite absolute production URLs to site-relative paths so the landing
+  // page works on both production and PR preview deployments.
+  markdown = markdown.replace(
+    /https:\/\/elft3r\.github\.io\/presentations\//g,
+    './'
+  );
+  const rendered = marked.parse(markdown);
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Presentations</title>
+  <style>
+    :root {
+      --bg: #F8F9FA;
+      --text: #2d3748;
+      --heading: #1a202c;
+      --accent: #24584C;
+      --link: #B39A6A;
+      --link-hover: #6E5C3A;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
+      font-size: 18px;
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    main {
+      max-width: 720px;
+      width: 100%;
+      padding: 3rem 1.5rem;
+    }
+    h1, h2, h3 {
+      color: var(--heading);
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      line-height: 1.2;
+      margin: 0 0 1rem;
+    }
+    h1 { font-size: 2.5rem; border-bottom: 4px solid var(--accent); padding-bottom: 0.5rem; }
+    p { margin: 0 0 1rem; }
+    a { color: var(--link); text-decoration: none; border-bottom: 1px solid currentColor; }
+    a:hover, a:focus { color: var(--link-hover); }
+    ul { padding-left: 1.25rem; }
+    li { margin: 0.4rem 0; }
+    img { max-width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+  <main>
+${rendered}  </main>
+</body>
+</html>
+`;
+  fs.writeFileSync(path.join(siteDir, 'index.html'), html);
 }
 
 console.log('\nBuild complete! Output in _site/');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -4,8 +4,17 @@ const { marked } = require('marked');
 
 const ROOT = path.resolve(__dirname, '..');
 const REVEAL_DIR = path.join(ROOT, 'node_modules', 'reveal.js');
+const PKG = require(path.join(ROOT, 'package.json'));
 
 const { PRESENTATIONS } = require('./presentations');
+
+// Drop raw HTML from rendered Markdown so a malicious or accidental
+// <script>/<iframe> in README.md cannot reach the public landing page.
+marked.use({
+  renderer: {
+    html: () => '',
+  },
+});
 
 const STOCK_PLUGINS = ['highlight', 'markdown', 'notes'];
 
@@ -85,12 +94,13 @@ const readme = path.join(ROOT, 'README.md');
 if (fs.existsSync(readme)) {
   console.log('\nRendering README.md to _site/index.html...');
   let markdown = fs.readFileSync(readme, 'utf8');
-  // Rewrite absolute production URLs to site-relative paths so the landing
+  // Rewrite the configured homepage to a site-relative path so the landing
   // page works on both production and PR preview deployments.
-  markdown = markdown.replace(
-    /https:\/\/elft3r\.github\.io\/presentations\//g,
-    './'
-  );
+  if (PKG.homepage) {
+    const homepage = PKG.homepage.endsWith('/') ? PKG.homepage : PKG.homepage + '/';
+    const escaped = homepage.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    markdown = markdown.replace(new RegExp(escaped, 'g'), './');
+  }
   const rendered = marked.parse(markdown);
   const html = `<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Pass `gitHubToken` to the wrangler-action `pages deploy` step so each PR's
Cloudflare preview registers a GitHub Deployment, surfacing a "Deployments"
entry in the PR sidebar alongside the existing per-presentation bot comment.
Adds the `deployments: write` permission this requires.

Also replaces the dead `_site/README.md` copy with a real `_site/index.html`
rendered from README.md via marked, themed to match the decks. Production
GitHub Pages doesn't run Jekyll under `actions/deploy-pages@v4`, so the
bare site URL was 404'ing — which would have made the new "View deployment"
link land on nothing. README links are rewritten to site-relative paths so
the page works on both production and Cloudflare preview origins.