### PR TITLE
Refactor community roles into dedicated card component

### DIFF
--- a/custom-themes/white_contrast_compact_verbatim_headers.css
+++ b/custom-themes/white_contrast_compact_verbatim_headers.css
@@ -461,6 +461,36 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   margin-bottom: 0;
 }
 
+/* Community engagement card: compact card highlighting past community roles */
+.reveal .community-card {
+  padding: 0.5em 1.1em 0.6em;
+}
+
+.reveal .community-card__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.3em;
+  font-size: 0.6em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--r-accent-color);
+}
+
+.reveal .community-card__title .badge {
+  margin-left: auto;
+}
+
+.reveal .community-card .styled-list {
+  margin: 0;
+  font-size: 0.78em;
+}
+
+.reveal .community-card .styled-list li {
+  margin-bottom: 0.15em;
+}
+
 /*********************************************
  * ICON ACCENT
  *********************************************/

--- a/shared/sections/jochen.html
+++ b/shared/sections/jochen.html
@@ -6,13 +6,19 @@
       <li>Software Development Background</li>
       <li>Infrastructure Full-Stack Engineer</li>
       <li>Lecturer BFH</li>
-      <li>AWS Community Builder <span class="badge">former</span></li>
-      <li>Docker Community Leader <span class="badge">former</span></li>
-      <li>
-        CNCF Co-Chair Infrastructure Lifecycle Working Group
-        <span class="badge">former</span>
-      </li>
     </ul>
+    <div class="card community-card mt-4">
+      <h3 class="community-card__title">
+        <i class="fa-solid fa-people-group" aria-hidden="true"></i>
+        Community Engagement
+        <span class="badge">past roles</span>
+      </h3>
+      <ul class="styled-list">
+        <li>AWS Community Builder</li>
+        <li>Docker Community Leader</li>
+        <li>CNCF Co-Chair Infrastructure Lifecycle Working Group</li>
+      </ul>
+    </div>
   </div>
   <div class="col-span-1 flex items-center justify-center">
     <img
@@ -22,7 +28,7 @@
     />
   </div>
 </div>
-<div class="mt-12">
+<div class="mt-8">
   <div class="social-links flex justify-center gap-4">
     <a
       href="https://www.linkedin.com/in/jochen-zehnder/"


### PR DESCRIPTION
## Summary
Reorganizes Jochen Zehnder's community engagement history into a dedicated, visually distinct card component with improved styling and semantic structure.

## Changes
- **New CSS component** (`.community-card`): Added styling for a compact community engagement card in `white_contrast_compact_verbatim_headers.css`
  - Card padding and title styling with icon support
  - Badge positioning (right-aligned)
  - Styled list integration with reduced margins and font size
  
- **HTML refactor** (`shared/sections/jochen.html`):
  - Moved past community roles (AWS Community Builder, Docker Community Leader, CNCF Co-Chair) from inline list into a dedicated `.community-card` component
  - Added icon (`fa-solid fa-people-group`) and "past roles" badge for visual clarity
  - Reduced top margin spacing (`mt-12` → `mt-8`) to accommodate new card layout

## Implementation Details
- Reuses existing `.card`, `.badge`, and `.styled-list` component classes for consistency with the design system
- Community roles are now semantically grouped and visually separated from current roles
- Icon and badge provide clear visual hierarchy and context for past engagement

https://claude.ai/code/session_012bpcSwzxj1PRipkRZ8nMBY